### PR TITLE
feat: add 3 new paths (genre/fiction, genre/nonfiction) and ISBN lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const express = require("express"); //third party module
 const app = express();// instance of the app
-const { bookSeries_setOne, bookSeries_setTwo, findAuthorsByLetter } = require("./series");
+const { bookSeries_setOne, bookSeries_setTwo, findAuthorsByLetter, findBookByISBN, listBooksByGenre } = require("./series");
 const fs = require("fs");
 
 //test using the core module fs
@@ -53,6 +53,26 @@ app.get('/bookList2', (req, res) => {
     let answer = bookSeries_setTwo;
     return res.json({ bookObj: answer });
 });
+
+// lookup book by ISBN
+app.get('/isbn-lookup/:isbn', (req, res) => {
+    let isbn = req.params.isbn;
+    let answer = findBookByISBN(isbn);
+    return res.json({ answer: answer });
+});
+
+// 
+app.get('/genre/nonfiction', (req, res) => {
+    let genre = 'nonfiction';
+    let answer = listBooksByGenre(genre);
+    return res.json({ answer: answer });
+})
+app.get('/genre/fiction', (req, res) => {
+    let genre = 'fiction';
+    let answer = listBooksByGenre(genre);
+    return res.json({ answer: answer });
+})
+
 app.get('/search/:letter', (req, res) => {
     let letter = req.params.letter;
     let answer = findAuthorsByLetter(letter);

--- a/series.js
+++ b/series.js
@@ -4,18 +4,21 @@ const bookSeries_setOne = {
         author: "a author",
         coverImage: "url of image",
         pageCount: 321,
+        genre: "fiction"
     },
     book2: {
         name: "title two",
         author: "b author",
         coverImage: "url of image",
         pageCount: 411,
+        genre: "fiction"
     },
     book3: {
         name: "title three",
         author: "c author",
         coverImage: "url of image",
         pageCount: 621,
+        genre: "fiction"
     },
 };
 
@@ -25,33 +28,42 @@ const bookSeries_setTwo = {
         author: "a author",
         coverImage: "url of image",
         pageCount: 321,
+        genre: "fiction"
     },
     book2: {
         name: "title two",
         author: "b author",
         coverImage: "url of image",
         pageCount: 411,
+        genre: "fiction"
     },
     book3: {
         name: "title three",
         author: "c author",
         coverImage: "url of image",
         pageCount: 621,
+        genre: "fiction"
     },
     book4: {
         name: "title four",
         author: "d author",
         coverImage: "url of image",
         pageCount: 502,
+        genre: "fiction"
     },
     book5: {
         name: "title five",
         author: "e author",
         coverImage: "url of image",
         pageCount: 555,
+        genre: "fiction"
     },
 };
 
+const books = [
+    ...Object.values(bookSeries_setOne),
+    ...Object.values(bookSeries_setTwo)
+];
 
 function findAuthorsByLetter(letter) {
     const bookSeriesArray = [bookSeries_setOne, bookSeries_setTwo];
@@ -97,6 +109,20 @@ if (authors.length > 0) {
     console.log(`No authors found whose names start with the letter "${letter}".`);
 }
 
+function findBookByISBN(isbn) {
+    return ('test ISBN lookup.  Submitted number:', isbn)
+}
+
+function listBooksByGenre(genre) {
+    const booksInGenre = [];
+
+for (const book of books) {
+    if (book.genre === genre) {
+        booksInGenre.push(book);
+    }
+}
+return booksInGenre;
+}
 
 function findAuthorsByLetter2(letter) {
     const bookSeriesArray = [bookSeries_setOne, bookSeries_setTwo];
@@ -110,5 +136,7 @@ function findAuthorsByLetter2(letter) {
 module.exports = {
     bookSeries_setOne,
     bookSeries_setTwo,
-    findAuthorsByLetter
+    findAuthorsByLetter,
+    findBookByISBN,
+    listBooksByGenre
 }


### PR DESCRIPTION
http://localhost:8000/genre/fiction
http://localhost:8000/genre/nonfiction
http://localhost:8000/isbn-lookup/123456 
     - 123456 is a placeholder and can be replaced with any ISBN.  ISBN search isn't fully implemented since there's no ISBN attached to books, but once they're added, the code that needs to be added should be very similar to the genre lookup function